### PR TITLE
Fix installer to use nanocloud/community:0.2 from Docker Hub

### DIFF
--- a/installer/installer.sh
+++ b/installer/installer.sh
@@ -33,5 +33,5 @@ if [ -z "$(which docker-compose)" ]; then
   exit 2
 fi
 
-docker run -e HOST_UID=$SCRIPT_UID -v $CURRENT_DIR/nanocloud:/var/lib/nanocloud community
+docker run -e HOST_UID=$SCRIPT_UID -v $CURRENT_DIR/nanocloud:/var/lib/nanocloud nanocloud/community:0.2
 $CURRENT_DIR/nanocloud/installation_dir/scripts/start.sh


### PR DESCRIPTION
Installer previously expected to find an image called community in the local repository. It now fetches it from docker hub with tag 0.2

Note : This can't work yet because nanocloud/community:0.2 have not been uploaded to the Docker Hub
